### PR TITLE
Refactor loan return to use LoanResponseDTO

### DIFF
--- a/src/main/java/com/biblioteca/controller/LoanController.java
+++ b/src/main/java/com/biblioteca/controller/LoanController.java
@@ -42,8 +42,8 @@ public class LoanController {
     }
 
     @PatchMapping("/{id}/return")
-    public ResponseEntity<Loan> returnLoan(@PathVariable Long id) {
-        Loan returnedLoan = loanService.returnLoan(id);
+    public ResponseEntity<LoanResponseDTO> returnLoan(@PathVariable Long id) {
+        LoanResponseDTO returnedLoan = loanService.returnLoan(id);
         return ResponseEntity.ok(returnedLoan);
     }
 }

--- a/src/main/java/com/biblioteca/service/LoanService.java
+++ b/src/main/java/com/biblioteca/service/LoanService.java
@@ -65,7 +65,7 @@ public class LoanService {
     }
 
     @Transactional
-    public Loan returnLoan(Long loanId) {
+    public LoanResponseDTO returnLoan(Long loanId) {
         Loan loan = loanRepository.findById(loanId)
                 .orElseThrow(() -> new ResourceNotFoundException("Empréstimo não encontrado com ID: " + loanId));
 
@@ -83,7 +83,9 @@ public class LoanService {
         loan.setReturnDate(LocalDate.now());
         loan.setStatus(LoanStatus.DEVOLVIDO);
 
-        return loanRepository.save(loan);
+        Loan savedLoan = loanRepository.save(loan);
+
+        return convertToResponseDTO(savedLoan);
     }
 
     @Transactional(readOnly = true)

--- a/src/test/java/com/biblioteca/controller/LoanController.java
+++ b/src/test/java/com/biblioteca/controller/LoanController.java
@@ -11,8 +11,6 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
-import org.springframework.data.domain.PageImpl;
-import org.springframework.data.domain.Pageable;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
@@ -78,7 +76,6 @@ class LoanControllerTest {
     @Test
     @DisplayName("Deve retornar status 200 e um empréstimo ao buscar por ID do usuário existente com o DTO de resposta")
     void getLoanById_WithExistingUserId_ShouldReturnOk() throws Exception {
-        // Crie o DTO que você espera que o serviço retorne
         LoanResponseDTO responseDTO = new LoanResponseDTO();
         responseDTO.setId(1L);
         responseDTO.setStatus(LoanStatus.ATIVO);
@@ -93,11 +90,11 @@ class LoanControllerTest {
     @Test
     @DisplayName("Deve retornar status 200 e um retorno empréstimo ao retornar um empréstimo buscando por Id")
     void returnLoanById_WithExistingId_ShouldReturnOk() throws Exception {
-        Loan returnedLoan = new Loan();
-        returnedLoan.setId(1L);
-        returnedLoan.setStatus(LoanStatus.DEVOLVIDO);
+        LoanResponseDTO responseDTO = new LoanResponseDTO();
+        responseDTO.setId(1L);
+        responseDTO.setStatus(LoanStatus.DEVOLVIDO);
 
-        given(loanService.returnLoan(1L)).willReturn(returnedLoan);
+        given(loanService.returnLoan(1L)).willReturn(responseDTO);
 
         mockMvc.perform(patch("/api/loans/1/return"))
                 .andExpect(status().isOk())

--- a/src/test/java/com/biblioteca/service/BookService.java
+++ b/src/test/java/com/biblioteca/service/BookService.java
@@ -2,7 +2,6 @@ package com.biblioteca.service;
 
 import com.biblioteca.entity.Book;
 import com.biblioteca.entity.BookStatus;
-import com.biblioteca.entity.Users;
 import com.biblioteca.exception.ResourceNotFoundException;
 import com.biblioteca.repository.BookRepository;
 import org.junit.jupiter.api.BeforeEach;
@@ -12,10 +11,6 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-import org.springframework.data.domain.Page;
-import org.springframework.data.domain.PageImpl;
-import org.springframework.data.domain.PageRequest;
-import org.springframework.data.domain.Pageable;
 
 import java.util.List;
 import java.util.Optional;


### PR DESCRIPTION
Updated the returnLoan method in LoanService and LoanController to return LoanResponseDTO instead of Loan. Adjusted related tests to expect and handle LoanResponseDTO. Added additional test cases for error scenarios in LoanServiceTest.